### PR TITLE
Leave ASC disabled

### DIFF
--- a/Adafruit_SCD30.cpp
+++ b/Adafruit_SCD30.cpp
@@ -98,9 +98,6 @@ bool Adafruit_SCD30::_init(int32_t sensor_id) {
   if (!setMeasurementInterval(2)) {
     return false;
   }
-  if (!selfCalibrationEnabled(true)) {
-    return false;
-  }
   humidity_sensor = new Adafruit_SCD30_Humidity(this);
   temp_sensor = new Adafruit_SCD30_Temp(this);
   return true;

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To install, use the Arduino Library Manager and search for "Adafruit SCD30" and 
 p
 # Contributing
 
-Contributions are welcome! Please read our [Code of Conduct](https://github.com/adafruit/Adafruit_SCD30/blob/master/CODE_OF_CONDUCT.md>)
+Contributions are welcome! Please read our [Code of Conduct](https://github.com/adafruit/Adafruit_SCD30/blob/master/code-of-conduct.md)
 before contributing to help this project stay welcoming.
 
 ## Documentation and doxygen

--- a/examples/sensor_tuning/sensor_tuning.ino
+++ b/examples/sensor_tuning/sensor_tuning.ino
@@ -26,7 +26,7 @@ void setup(void) {
   ***/
 
 
-  /*** Adjust the rate at which measurements are taken, from 5-1800 seconds */
+  /*** Adjust the rate at which measurements are taken, from 2-1800 seconds */
   // if (!scd30.setMeasurementInterval(5)) {
   //   Serial.println("Failed to set measurement interval");
   //   while(1){ delay(10);}
@@ -49,7 +49,9 @@ void setup(void) {
 
 
   /*** Set an altitude offset in meters above sea level.
-   * Setting an altitude offset will override any pressure offset ***/
+   * Offset value stored in non-volatile memory of SCD30.
+   * Setting an altitude offset will override any pressure offset.
+   */
   // if (!scd30.setAltitudeOffset(110)){
   //   Serial.println("Failed to set measurement interval");
   //   while(1){ delay(10);}
@@ -59,7 +61,9 @@ void setup(void) {
   Serial.println(" meters");
 
 
-  /*** Set a temperature offset in hundredths of a degree celcius ***/
+  /*** Set a temperature offset in hundredths of a degree celcius.
+   * Offset value stored in non-volatile memory of SCD30.
+   */
   // if (!scd30.setTemperatureOffset(1984)){ // 19.84 degrees celcius
   //   Serial.println("Failed to set temperature offset");
   //   while(1){ delay(10);}
@@ -71,7 +75,9 @@ void setup(void) {
 
   /*** Force the sensor to recalibrate with the given reference value
    * from 400-2000 ppm. Writing a recalibration reference will overwrite
-   * any previous self calibration values                          ***/
+   * any previous self calibration values.
+   * Reference value stored in non-volatile memory of SCD30.
+   */
   // if (!scd30.forceRecalibrationWithReference(400)){
   //   Serial.println("Failed to force recalibration with reference");
   //   while(1) { delay(10); }
@@ -81,10 +87,13 @@ void setup(void) {
   Serial.println(" ppm");
 
 
-  /*** Enable or disable automatic self calibration
+  /*** Enable or disable automatic self calibration (ASC).
+   * Parameter stored in non-volatile memory of SCD30.
    * Enabling self calibration will override any previously set
-   * forced calibration value
-  ***/
+   * forced calibration value.
+   * ASC needs continuous operation with at least 1 hour
+   * 400ppm CO2 concentration daily.
+   */
   // if (!scd30.selfCalibrationEnabled(true)){
   //   Serial.println("Failed to enable or disable self calibration");
   //   while(1) { delay(10); }


### PR DESCRIPTION
This PR will not activate ASC in `_init()` as default and add some additional information to the examples.