### PR TITLE
rename eCO2 to CO2

### DIFF
--- a/Adafruit_SCD30.cpp
+++ b/Adafruit_SCD30.cpp
@@ -1,11 +1,11 @@
 /*!
  *  @file Adafruit_SCD30.cpp
  *
- *  @mainpage Adafruit SCD30 eCO2, Temperature, and Humidity sensor
+ *  @mainpage Adafruit SCD30 CO2, Temperature, and Humidity sensor
  *
  *  @section intro_sec Introduction
  *
- * 	I2C Driver for the Library for the SCD30 eCO2, Temperature, and Humidity
+ * 	I2C Driver for the Library for the SCD30 CO2, Temperature, and Humidity
  * sensor
  *
  * 	This is a library for the Adafruit SCD30 breakout:
@@ -316,7 +316,7 @@ bool Adafruit_SCD30::read(void) {
   hum <<= 8;
   hum |= buffer[16];
 
-  memcpy(&eCO2, &co2, sizeof(eCO2));
+  memcpy(&CO2, &co2, sizeof(CO2));
   memcpy(&temperature, &temp, sizeof(temperature));
   memcpy(&relative_humidity, &hum, sizeof(relative_humidity));
 

--- a/Adafruit_SCD30.h
+++ b/Adafruit_SCD30.h
@@ -1,7 +1,7 @@
 /*!
  *  @file Adafruit_SCD30.h
  *
- * 	I2C Driver for the Adafruit SCD30 eCO2, Temperature, and Humidity sensor
+ * 	I2C Driver for the Adafruit SCD30 CO2, Temperature, and Humidity sensor
  * 	This is a library is written to work with the Adafruit SCD30 breakout:
  * 	https://www.adafruit.com/products/48xx
  *
@@ -90,7 +90,7 @@ private:
 
 /*!
  *    @brief  Class that stores state and functions for interacting with
- *            the SCD30 eCO2, Temperature, and Humidity sensor
+ *            the SCD30 CO2, Temperature, and Humidity sensor
  */
 class Adafruit_SCD30 {
 public:
@@ -126,7 +126,7 @@ public:
 
   Adafruit_Sensor *getTemperatureSensor(void);
   Adafruit_Sensor *getHumiditySensor(void);
-  float eCO2,            ///< The most recent eCO2 reading
+  float CO2,            ///< The most recent CO2 reading
       temperature,       ///< The most recent temperature reading
       relative_humidity; ///< The most recent relative_humidity reading
   ;

--- a/Adafruit_SCD30.h
+++ b/Adafruit_SCD30.h
@@ -126,7 +126,7 @@ public:
 
   Adafruit_Sensor *getTemperatureSensor(void);
   Adafruit_Sensor *getHumiditySensor(void);
-  float CO2,            ///< The most recent CO2 reading
+  float CO2,             ///< The most recent CO2 reading
       temperature,       ///< The most recent temperature reading
       relative_humidity; ///< The most recent relative_humidity reading
   ;

--- a/examples/adafruit_scd30_test/adafruit_scd30_test.ino
+++ b/examples/adafruit_scd30_test/adafruit_scd30_test.ino
@@ -41,8 +41,8 @@ void loop() {
     Serial.print(scd30.relative_humidity);
     Serial.println(" %");
     
-    Serial.print("eCO2: ");
-    Serial.print(scd30.eCO2, 3);
+    Serial.print("CO2: ");
+    Serial.print(scd30.CO2, 3);
     Serial.println(" ppm");
     Serial.println("");
   } else {

--- a/examples/oled_co2_monitor/oled_co2_monitor.ino
+++ b/examples/oled_co2_monitor/oled_co2_monitor.ino
@@ -1,4 +1,4 @@
-// A simple eCO2 meter using the Adafruit SCD30 breakout and the Adafruit 128x32 OLEDs
+// A simple CO2 meter using the Adafruit SCD30 breakout and the Adafruit 128x32 OLEDs
 #include <Adafruit_SCD30.h>
 #include <Adafruit_SSD1306.h>
 
@@ -9,7 +9,7 @@ void setup(void) {
   Serial.begin(115200);
   while (!Serial) delay(10);     // will pause Zero, Leonardo, etc until serial console opens
 
-  Serial.println("SCD30 OLED eCO2 meter!");
+  Serial.println("SCD30 OLED CO2 meter!");
 
   // Try to initialize!
   if (!scd30.begin()) {
@@ -57,13 +57,13 @@ void loop() {
       return;
     }
 
-    Serial.print("eCO2: ");
-    Serial.print(scd30.eCO2, 3);
+    Serial.print("CO2: ");
+    Serial.print(scd30.CO2, 3);
     Serial.println(" ppm");
     Serial.println("");
 
-    display.println("eCO2:"); 
-    display.print(scd30.eCO2, 2);
+    display.println("CO2:");
+    display.print(scd30.CO2, 2);
 
     display.setTextSize(1);
 

--- a/examples/sensor_tuning/sensor_tuning.ino
+++ b/examples/sensor_tuning/sensor_tuning.ino
@@ -123,8 +123,8 @@ void loop() {
     Serial.print(scd30.relative_humidity);
     Serial.println(" %");
     
-    Serial.print("eCO2: ");
-    Serial.print(scd30.eCO2, 3);
+    Serial.print("CO2: ");
+    Serial.print(scd30.CO2, 3);
     Serial.println(" ppm");
     Serial.println("");
   }


### PR DESCRIPTION
changing all occurances of "eCO2" to "CO2" in code; no functional changes, as discussed in PR #4
