### PR TITLE
Update _init() to get around reset() oddness.

### DIFF
--- a/Adafruit_SCD30.cpp
+++ b/Adafruit_SCD30.cpp
@@ -94,7 +94,8 @@ bool Adafruit_SCD30::_init(int32_t sensor_id) {
 
   // first I2C xfer after reset can fail, double tapping seems to get by it
   if (!startContinuousMeasurement()) {
-    if (!startContinuousMeasurement()) return false;
+    if (!startContinuousMeasurement())
+      return false;
   }
   if (!setMeasurementInterval(2)) {
     return false;

--- a/Adafruit_SCD30.cpp
+++ b/Adafruit_SCD30.cpp
@@ -92,8 +92,9 @@ bool Adafruit_SCD30::_init(int32_t sensor_id) {
 
   reset();
 
+  // first I2C xfer after reset can fail, double tapping seems to get by it
   if (!startContinuousMeasurement()) {
-    return false;
+    if (!startContinuousMeasurement()) return false;
   }
   if (!setMeasurementInterval(2)) {
     return false;
@@ -409,7 +410,7 @@ void Adafruit_SCD30::fillTempEvent(sensors_event_t *temp, uint32_t timestamp) {
 
 /**************************************************************************/
 /*!
-    @brief  Gets the sensor_t data for the SCD30's tenperature
+    @brief  Gets the sensor_t data for the SCD30's humidity
 */
 /**************************************************************************/
 void Adafruit_SCD30_Humidity::getSensor(sensor_t *sensor) {
@@ -421,7 +422,7 @@ void Adafruit_SCD30_Humidity::getSensor(sensor_t *sensor) {
   sensor->name[sizeof(sensor->name) - 1] = 0;
   sensor->version = 1;
   sensor->sensor_id = _sensorID;
-  sensor->type = SENSOR_TYPE_PRESSURE;
+  sensor->type = SENSOR_TYPE_RELATIVE_HUMIDITY;
   sensor->min_delay = 0;
   sensor->min_value = 260;
   sensor->max_value = 1260;


### PR DESCRIPTION
This is a fix for #9 but also fixes typos mentioned in #8.

The change is a bit hackish, but works. At least for now.

![Screenshot from 2021-03-02 15-46-22](https://user-images.githubusercontent.com/8755041/109730545-7f762400-7b6e-11eb-8794-28038e73832a.png)

Same thing with debug off to show several sensor readings.
![Screenshot from 2021-03-02 15-47-57](https://user-images.githubusercontent.com/8755041/109730664-b3514980-7b6e-11eb-82b3-112f5f2740ba.png)



