### PR TITLE
Add I2C delay

### DIFF
--- a/Adafruit_SCD30.cpp
+++ b/Adafruit_SCD30.cpp
@@ -347,7 +347,9 @@ uint16_t Adafruit_SCD30::readRegister(uint16_t reg_address) {
   buffer[0] = (reg_address >> 8) & 0xFF;
   buffer[1] = reg_address & 0xFF;
   // the SCD30 really wants a stop before the read!
-  i2c_dev->write_then_read(buffer, 2, buffer, 2, true);
+  i2c_dev->write(buffer, 2);
+  delay(4); // delay between write and read specified by the datasheet
+  i2c_dev->read(buffer, 2);
   return (uint16_t)(buffer[0] << 8 | (buffer[1] & 0xFF));
 }
 


### PR DESCRIPTION
As mentioned in #14 and fixes #12. Adds delay between read and write per datasheet.

Running test sketch from #12 on a Feather ESP32. Note change in reported measurement interval and temperature offset.

**BEFORE**
![Screenshot from 2021-06-15 13-58-50](https://user-images.githubusercontent.com/8755041/122122993-535f7580-cde2-11eb-9871-89247d97f01c.png)

**AFTER**
![Screenshot from 2021-06-15 14-00-05](https://user-images.githubusercontent.com/8755041/122123056-64a88200-cde2-11eb-9ba0-def61fdc63e6.png)

