### PR TITLE
Prevent compiler warnings: remove unused variables and move internal function declaration out of header

### DIFF
--- a/Adafruit_SCD30.cpp
+++ b/Adafruit_SCD30.cpp
@@ -266,9 +266,7 @@ uint16_t Adafruit_SCD30::getForcedCalibrationReference(void) {
  * @return true: success false: failure
  */
 bool Adafruit_SCD30::read(void) {
-
   uint8_t buffer[18];
-  uint8_t crc = 0;
 
   buffer[0] = (SCD30_CMD_READ_MEASUREMENT >> 8) & 0xFF;
   buffer[1] = SCD30_CMD_READ_MEASUREMENT & 0xFF;
@@ -283,7 +281,6 @@ bool Adafruit_SCD30::read(void) {
     return false;
   }
 
-  uint8_t crc_buffer[2];
   // loop through the bytes we read, 3 at a time for i=MSB, i+1=LSB, i+2=CRC
   for (uint8_t i = 0; i < 18; i += 3) {
     if (crc8(buffer + i, 2) != buffer[i + 2]) {

--- a/Adafruit_SCD30.cpp
+++ b/Adafruit_SCD30.cpp
@@ -38,6 +38,8 @@
 
 #include "Adafruit_SCD30.h"
 
+static uint8_t crc8(const uint8_t *data, int len);
+
 /**
  * @brief Construct a new Adafruit_SCD30::Adafruit_SCD30 object
  *

--- a/Adafruit_SCD30.h
+++ b/Adafruit_SCD30.h
@@ -157,9 +157,6 @@ private:
   uint16_t getAmbiendPressure(void);
   uint8_t computeCRC8(uint8_t data[], uint8_t len);
   uint16_t readRegister(uint16_t reg_address);
-  // static uint8_t crc8(const uint8_t *data, int len);
 };
-
-static uint8_t crc8(const uint8_t *data, int len);
 
 #endif


### PR DESCRIPTION
These cause compiler warnings, so I wanted to remove them to reduce compiler noise during a build.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

It removes two unused variables - `crc` and `crc_buffer` - from `Adafruit_SCD30::read()`, and removes an unused function declaration - `crc8` - that is never defined.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

I don't know of any.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

I was able to build and run the `adafruit_scd30_test` example.