### PR TITLE
Add ability to specify the pressure offset at initialization

### DIFF
--- a/Adafruit_SCD30.cpp
+++ b/Adafruit_SCD30.cpp
@@ -65,10 +65,13 @@ Adafruit_SCD30::~Adafruit_SCD30(void) {
  *            The Wire object to be used for I2C connections.
  *    @param  sensor_id
  *            The unique ID to differentiate the sensors from others
+ *    @param  pressure_offset_mbar
+ *            Ambient pressure offset (in mbar) to use when initializing; 0 to
+ *            deactivate pressure compensation.
  *    @return True if initialization was successful, otherwise false.
  */
 bool Adafruit_SCD30::begin(uint8_t i2c_address, TwoWire *wire,
-                           int32_t sensor_id) {
+                           int32_t sensor_id, int16_t pressure_offset_mbar) {
   if (i2c_dev) {
     delete i2c_dev; // remove old interface
   }
@@ -79,15 +82,18 @@ bool Adafruit_SCD30::begin(uint8_t i2c_address, TwoWire *wire,
     return false;
   }
 
-  return _init(sensor_id);
+  return _init(sensor_id, pressure_offset_mbar);
 }
 // bool Adafruit_SCD30::begin_UART(void){}
 
 /*!  @brief Initializer for post i2c init
  *   @param sensor_id Optional unique ID for the sensor set
+ *   @param pressure_offset_mbar
+ *          Ambient pressure offset (in mbar) to use when initializing; 0 to
+ *          deactivate pressure compensationn.
  *   @returns True if chip identified and initialized
  */
-bool Adafruit_SCD30::_init(int32_t sensor_id) {
+bool Adafruit_SCD30::_init(int32_t sensor_id, int16_t pressure_offset_mbar) {
 
   _sensorid_humidity = sensor_id;
   _sensorid_temp = sensor_id + 1;
@@ -95,8 +101,8 @@ bool Adafruit_SCD30::_init(int32_t sensor_id) {
   reset();
 
   // first I2C xfer after reset can fail, double tapping seems to get by it
-  if (!startContinuousMeasurement()) {
-    if (!startContinuousMeasurement())
+  if (!startContinuousMeasurement(pressure_offset_mbar)) {
+    if (!startContinuousMeasurement(pressure_offset_mbar))
       return false;
   }
   if (!setMeasurementInterval(2)) {

--- a/Adafruit_SCD30.h
+++ b/Adafruit_SCD30.h
@@ -98,7 +98,7 @@ public:
   ~Adafruit_SCD30();
 
   bool begin(uint8_t i2c_addr = SCD30_I2CADDR_DEFAULT, TwoWire *wire = &Wire,
-             int32_t sensor_id = 0);
+             int32_t sensor_id = 0, int16_t pressure_offset_mbar = 0);
 
   void reset(void);
   bool dataReady(void);
@@ -132,7 +132,7 @@ public:
   ;
 
 protected:
-  virtual bool _init(int32_t sensor_id);
+  virtual bool _init(int32_t sensor_id, int16_t pressure_offset_mbar);
 
   uint16_t _sensorid_humidity, ///< ID number for humidity
       _sensorid_temp;          ///< ID number for temperature
@@ -154,7 +154,6 @@ private:
   void fillTempEvent(sensors_event_t *temp, uint32_t timestamp);
   bool sendCommand(uint16_t command, uint16_t argument);
   bool sendCommand(uint16_t command);
-  uint16_t getAmbiendPressure(void);
   uint8_t computeCRC8(uint8_t data[], uint8_t len);
   uint16_t readRegister(uint16_t reg_address);
 };


### PR DESCRIPTION
Fixes #19.

The SCD30 only allows you to do this at startup, but the pressure offset is hard-coded in the library. Add an optional pressure offset to Adafruit_SCD30::begin.

This is an API-breaking change, since objects that override Adafruit_SCD30::_init will have the wrong signature. This is done intentionally; any objects that override _init need to take into account the new argument to Adafruit_SCD30::begin.

Also get rid of the unused decl for getAmbiendPressure.